### PR TITLE
ci: fix permissions for workflows

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,8 @@ jobs:
   title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
... failed with

```
[4:14:11 PM] [semantic-release] › ✘  The command "git push --dry-run --no-verify https://x-access-token:[secure]@github.com/kayman-mk/A-Statistician-Plays-Darts HEAD:main" failed with the error message remote: Permission to kayman-mk/A-Statistician-Plays-Darts.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kayman-mk/A-Statistician-Plays-Darts/': The requested URL returned error: 403.
```

... failed with

```
Error: Resource not accessible by integration
```